### PR TITLE
olsr Makefile: version 0.6.5 no longer supported, updated to 0.6.7

### DIFF
--- a/olsrd-ninux/Makefile
+++ b/olsrd-ninux/Makefile
@@ -9,13 +9,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=olsrd-ninux
-PKG_VERSION:=0.6.5-pre
+PKG_VERSION:=0.6.7
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/olsrd-ninux-$(PKG_VERSION)/
 PKG_SOURCE:=olsrd-ninux-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=git://olsr.org/olsrd.git
-PKG_SOURCE_VERSION:=origin/release-0.6.5
+PKG_SOURCE_VERSION:=origin/release-0.6.7
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1


### PR DESCRIPTION
il makefile punta al branch di olsr release-0.6.5 non più presente.
è stato aggiornato al branch release-0.6.7.
Bella! 
